### PR TITLE
Add better dictionary parsing, support emoji in table

### DIFF
--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -1,0 +1,4 @@
+.table-row-cell {
+    -fx-font-family: "Apple Color Emoji", "Segoe UI Symbol", "Arial", sans-serif;
+}
+

--- a/src/main/resources/view/DictionaryContentPane.fxml
+++ b/src/main/resources/view/DictionaryContentPane.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.AnchorPane?>
+
 <AnchorPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.DictionaryContentPaneController">
     <TableView fx:id="table" prefHeight="400.0" prefWidth="248.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <columns>

--- a/src/main/scala/bozzy/Bozzy.scala
+++ b/src/main/scala/bozzy/Bozzy.scala
@@ -20,6 +20,9 @@ object Bozzy extends JFXApp {
 
   stage = new PrimaryStage() {
     title = "Bozzy"
-    scene = new Scene(root)
+    scene = new Scene(root) {
+      stylesheets = List(getClass.getResource("/css/style.css").toExternalForm)
+    }
+
   }
 }

--- a/src/main/scala/bozzy/steno/DictionaryEntry.scala
+++ b/src/main/scala/bozzy/steno/DictionaryEntry.scala
@@ -5,10 +5,9 @@ import scalafx.beans.property.{ObjectProperty, StringProperty}
 /**
   * Created by ted on 2016-02-08.
   */
-class DictionaryEntry(val entry: String, val format: DictionaryFormat.Value, val name: String) {
-  val raw = entry
-  val translation = new Translation(entry, format)
-  val stroke = new Stroke(entry, format)
+class DictionaryEntry(entryStroke: String, entryTranslation: String, val format: DictionaryFormat.Value, val name: String) {
+  val translation = new Translation(entryTranslation, format)
+  val stroke = new Stroke(entryStroke, format)
   val dictionary_name = name
 
   // Readable columns.

--- a/src/main/scala/bozzy/steno/DictionaryFormat.scala
+++ b/src/main/scala/bozzy/steno/DictionaryFormat.scala
@@ -1,8 +1,47 @@
 package bozzy.steno
 
+import play.api.libs.json._
+
 /**
   * Created by ted on 2016-02-08.
   */
 object DictionaryFormat extends Enumeration {
   val RTF, JSON = Value
+  def parseJsonDictionary(jsonDictionaryString: String) = {
+    val jsonDictionary = Json.parse(jsonDictionaryString)
+    jsonDictionary.as[JsObject].keys.map((stroke: String) => {
+      val translation: String = jsonDictionary \ stroke match {
+        case JsDefined(v) => v.as[JsString].value
+        case _ => ""
+      }
+      (stroke, translation)
+    })
+  }
+  def parseRtfDictionary(dictionary: String) = {
+    dictionary.replaceAll("""\r?\n?""", "") // Ignore new lines
+      .split("""\{\\\*\\cxs """) // Look at each stroke
+      .drop(1) // Drop metadata
+      .flatMap((line: String) => {
+      val (stroke, translation) = DictionaryFormat.rtfLineToEntry(line, false)
+      if (stroke.isDefined && translation.isDefined) {
+        Option((stroke.get, translation.get))
+      } else {
+        None
+      }
+    })
+  }
+  def rtfLineToEntry(rtfLine: String, hasPrefix: Boolean = true): (Option[String], Option[String]) = {
+    val strokeBegin = "{\\*\\cxs "
+    val strokeEnd = "}"
+    val strokeBeginIndex = if (hasPrefix) rtfLine.indexOf(strokeBegin) + strokeBegin.length else 0
+    val strokeEndIndex = rtfLine.indexOf(strokeEnd, strokeBeginIndex)
+    if (strokeBeginIndex >= 0 && strokeEndIndex > strokeBeginIndex) {
+      (Some(rtfLine.substring(strokeBeginIndex, strokeEndIndex)),
+        Some(rtfLine.substring(strokeEndIndex + 1))
+      )
+    } else {
+      println(s"Trouble processing $rtfLine")
+      (None, None)
+    }
+  }
 }

--- a/src/main/scala/bozzy/steno/Stroke.scala
+++ b/src/main/scala/bozzy/steno/Stroke.scala
@@ -3,21 +3,6 @@ package bozzy.steno
 /**
   * Created by ted on 2016-02-08.
   */
-class Stroke(entry: String, format: DictionaryFormat.Value)  {
-  val raw: String = if (format == DictionaryFormat.JSON) {
-    val stroke = """"([^"]+)": "(.*)",?\w*$""".r
-    entry match {
-      case stroke(rawStroke, rawTranslation) => rawStroke
-      case _ => ""
-    }
-  } else if (format == DictionaryFormat.RTF) {
-    val stroke = """\{\\\*\\cxs ([^}]+)\}([^{]+).*$""".r
-    entry match {
-      case stroke(rawStroke, rawTranslation) => rawStroke
-      case _ => ""
-    }
-  } else {
-    ""
-  }
-  val chord_count :Int = raw.split('/').length
+class Stroke(val raw: String, format: DictionaryFormat.Value)  {
+  val chord_count: Int = (raw split '/').length
 }

--- a/src/main/scala/bozzy/steno/Translation.scala
+++ b/src/main/scala/bozzy/steno/Translation.scala
@@ -3,24 +3,6 @@ package bozzy.steno
 /**
   * Created by ted on 2016-02-08.
   */
-class Translation(entry: String, format: DictionaryFormat.Value) {
-  val raw: String = if (format == DictionaryFormat.JSON) {
-    val begin = entry.indexOf(": \"") + 3
-    val end = entry.lastIndexOf("\"")
-    if (entry != null && begin > 0 && end > begin) {
-      entry.substring(begin, end)
-    } else {
-      ""
-    }
-  } else if (format == DictionaryFormat.RTF) {
-    val stroke = """\{\\\*\\cxs ([^}]+)\}(.+?)(\{\\\*\\c.*)?""".r
-    entry match {
-      case stroke(rawStroke, rawTranslation) => rawTranslation
-      case stroke(rawStroke, rawTranslation, extra) => rawTranslation
-      case _ => ""
-    }
-  } else {
-    ""
-  }
-  val word_count: Int = raw.split(' ').length
+class Translation(val raw: String, val format: DictionaryFormat.Value) {
+  val word_count: Int = (raw split ' ').length
 }

--- a/src/test/scala/FilterTest.scala
+++ b/src/test/scala/FilterTest.scala
@@ -12,31 +12,31 @@ class FilterTest extends FlatSpec with Matchers{
   */
 
   "The filter function" should "keep entries if all queries are empty" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "main.rtf")
+    val entry = new DictionaryEntry("KOPB/SREPBGS", "convention", DictionaryFormat.RTF, "main.rtf")
     var filter = DictionaryEntry.filterDictionaryEntry(null, null, null, null, null)
     filter(entry) should equal(true)
     filter = DictionaryEntry.filterDictionaryEntry("", "", "", "", "")
     filter(entry) should equal(true)
   }
   "The filter function" should "be case insensitive" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "main.rtf")
-    var filter = DictionaryEntry.filterDictionaryEntry("CONVEN", "kopb", null, null, null)
+    val entry = new DictionaryEntry("KOPB/SREPBGS", "convention", DictionaryFormat.RTF, "main.rtf")
+    val filter = DictionaryEntry.filterDictionaryEntry("CONVEN", "kopb", null, null, null)
     filter(entry) should equal(true)
   }
   "The filter function" should "keep entries that contain the query" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "main.rtf")
-    var filter = DictionaryEntry.filterDictionaryEntry("tion", "SRE", "main.rtf", "2", "1")
+    val entry = new DictionaryEntry("KOPB/SREPBGS", "convention", DictionaryFormat.RTF, "main.rtf")
+    val filter = DictionaryEntry.filterDictionaryEntry("tion", "SRE", "main.rtf", "2", "1")
     filter(entry) should equal(true)
   }
   "The filter function" should "hide entries that do not contain the query" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "main.rtf")
+    val entry = new DictionaryEntry("KOPB/SREPBGS", "convention", DictionaryFormat.RTF, "main.rtf")
     var filter = DictionaryEntry.filterDictionaryEntry("tion", "SRE", "main.rtf", "2", "2")
     filter(entry) should equal(false)
     filter = DictionaryEntry.filterDictionaryEntry(" ", null, null, null, null)
     filter(entry) should equal(false)
   }
   "The filter function" should "keep entries if query does not make sense" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "main.rtf")
+    val entry = new DictionaryEntry("KOPB/SREPBGS", "convention", DictionaryFormat.RTF, "main.rtf")
     var filter = DictionaryEntry.filterDictionaryEntry(null, null, "main.rtf", "number", null)
     filter(entry) should equal(true)
     filter = DictionaryEntry.filterDictionaryEntry(null, null, "main.rtf", null, "number")

--- a/src/test/scala/StenoInstantiationTest.scala
+++ b/src/test/scala/StenoInstantiationTest.scala
@@ -10,29 +10,25 @@ class StenoInstantiationTest extends FlatSpec with Matchers {
   val RTFDictionary = Source.fromURL(getClass.getResource("/sampleRTFDictionary.rtf")).getLines()
   val JSONDictionary = Source.fromURL(getClass.getResource("/sampleJSONDictionary.json")).getLines()
 
-  "The Entry class" should "load a simple RTF translation" in {
-    var entry = new DictionaryEntry("{\\*\\cxs KOPB/SREPBGS}convention", DictionaryFormat.RTF, "name")
-    entry.stroke.raw should equal ("KOPB/SREPBGS")
-    entry.translation.raw should equal ("convention")
-    entry = new DictionaryEntry(
-      "{\\*\\cxs THR-L}there will{\\*\\cxsvatdictentrydate\\yr2016\\mo1\\da6}",
-      DictionaryFormat.RTF,
-      "name"
+  "rtfLineToEntry" should "load a simple RTF translation" in {
+    val (stroke, translation) = DictionaryFormat.rtfLineToEntry("{\\*\\cxs KOPB/SREPBGS}convention")
+    stroke.get should equal ("KOPB/SREPBGS")
+    translation.get should equal ("convention")
+
+    val (secondStroke, secondTranslation) = DictionaryFormat.rtfLineToEntry(
+      "{\\*\\cxs THR-L}there will{\\*\\cxsvatdictentrydate\\yr2016\\mo1\\da6}"
     )
-    entry.stroke.raw should equal ("THR-L")
-    entry.translation.raw should equal ("there will")
+    secondStroke.get should equal ("THR-L")
+    secondTranslation.get should equal ("there will{\\*\\cxsvatdictentrydate\\yr2016\\mo1\\da6}")
     }
-  "The Entry class" should "load a simple JSON translation" in {
-    var entry = new DictionaryEntry("\"KOPB/SREPBGS\": \"convention\",", DictionaryFormat.JSON, "name")
-    entry.stroke.raw should equal ("KOPB/SREPBGS")
-    entry.translation.raw should equal ("convention")
-    entry = new DictionaryEntry(
-      "\"TRAOEU/SER/TOPS\": \"Triceratops\",",
-      DictionaryFormat.JSON,
-      "name"
+  "parseJsonDictionary" should "load a simple JSON dictionary" in {
+    val entries = DictionaryFormat.parseJsonDictionary(
+      """{"KOPB/SREPBGS": "convention"}"""
     )
-    entry.stroke.raw should equal ("TRAOEU/SER/TOPS")
-    entry.translation.raw should equal ("Triceratops")
+    entries.size should equal (1)
+    val (stroke, translation) = entries.iterator.next()
+    stroke should equal ("KOPB/SREPBGS")
+    translation should equal ("convention")
   }
 
   "The StenoDictionary class" should "load a simple JSON dictionary" in {


### PR DESCRIPTION
- Now dictionary parsing is part of the DictionaryFormat object as functions
- Entry instead takes a stroke and translation property. Note that for RTF, the translation is unprocessed and still contains metadata.
- Font for table is set to an emoji compatible font, at least on OSX and Windows. OSX emojis look very small but at least they are visible.
- RTF loading defaults to UTF-8, and falls back to the more probably ANSI on exception.
- RTF loading is no longer tied to line breaks, especially because Magnum seems to treat line breaks as if they were salt and pepper to sprinkle on here and there.