### PR TITLE
Make UI layout more flexible and fix dictionary name on Windows

### DIFF
--- a/src/main/resources/view/DictionaryContentPane.fxml
+++ b/src/main/resources/view/DictionaryContentPane.fxml
@@ -2,18 +2,15 @@
 
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
-<?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.DictionaryContentPaneController">
-    <TableView fx:id="table" prefHeight="400.0" prefWidth="248.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-        <columns>
-            <TableColumn fx:id="strokeCol" text="Stroke" styleClass="mono-font"/>
-            <TableColumn fx:id="translationCol" text="Translation" styleClass="emoji-field" />
-            <TableColumn fx:id="wordCountCol" text="Words" />
-            <TableColumn fx:id="chordCountCol" text="Strokes" />
-        </columns>
-      <columnResizePolicy>
-         <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-      </columnResizePolicy>
-    </TableView>
-</AnchorPane>
+<TableView fx:id="table" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.DictionaryContentPaneController">
+    <columns>
+        <TableColumn fx:id="strokeCol" styleClass="mono-font" text="Stroke" />
+        <TableColumn fx:id="translationCol" styleClass="emoji-field" text="Translation" />
+        <TableColumn fx:id="wordCountCol" text="Words" />
+        <TableColumn fx:id="chordCountCol" text="Strokes" />
+    </columns>
+   <columnResizePolicy>
+      <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+   </columnResizePolicy>
+</TableView>

--- a/src/main/resources/view/DictionaryList.fxml
+++ b/src/main/resources/view/DictionaryList.fxml
@@ -4,55 +4,40 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.ListView?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.DictionaryListController">
-   <children>
-      <GridPane prefHeight="200.0" prefWidth="200.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints maxHeight="172.0" minHeight="10.0" prefHeight="31.0" vgrow="SOMETIMES" />
-          <RowConstraints maxHeight="295.0" minHeight="10.0" prefHeight="45.0" vgrow="SOMETIMES" />
-          <RowConstraints maxHeight="304.0" minHeight="10.0" prefHeight="94.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Dictionaries">
-               <font>
-                  <Font name="System Bold" size="14.0" />
-               </font>
-            </Text>
-            <ButtonBar buttonMinWidth="25.0" nodeOrientation="RIGHT_TO_LEFT" prefHeight="46.0" prefWidth="169.0" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1">
-              <buttons>
-                  <Button mnemonicParsing="false" onAction="#handleMoveUp" text="↑" ButtonBar.buttonData="RIGHT" />
-                  <Button mnemonicParsing="false" onAction="#handleMoveDown" text="↓" ButtonBar.buttonData="RIGHT" />
-                  <Button mnemonicParsing="false" onAction="#handleAdd" text="+" ButtonBar.buttonData="LEFT" />
-                  <Button mnemonicParsing="false" onAction="#handleRemove" text="-" ButtonBar.buttonData="LEFT" />
-              </buttons>
-            </ButtonBar>
-            <ScrollPane prefWidth="169" GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" GridPane.vgrow="ALWAYS">
-               <content>
-                  <ListView fx:id="dictionary_list">
-                     <opaqueInsets>
-                        <Insets />
-                     </opaqueInsets></ListView>
-               </content>
-            </ScrollPane>
-         </children>
-         <padding>
-            <Insets left="18.0" top="10.0" />
-         </padding>
-         <opaqueInsets>
-            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-         </opaqueInsets>
-      </GridPane>
-   </children>
-</AnchorPane>
+<GridPane vgap="10.0" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.DictionaryListController">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" />
+        <ColumnConstraints hgrow="SOMETIMES" />
+    </columnConstraints>
+    <rowConstraints>
+      <RowConstraints vgrow="SOMETIMES" />
+      <RowConstraints vgrow="SOMETIMES" />
+      <RowConstraints vgrow="SOMETIMES" />
+      <RowConstraints />
+    </rowConstraints>
+     <children>
+        <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Dictionaries" GridPane.columnSpan="2" GridPane.rowIndex="1">
+           <font>
+              <Font name="System Bold" size="14.0" />
+           </font>
+        </Text>
+        <ButtonBar buttonMinWidth="25.0" nodeOrientation="RIGHT_TO_LEFT" GridPane.columnSpan="2" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2">
+          <buttons>
+              <Button mnemonicParsing="false" onAction="#handleMoveUp" text="↑" ButtonBar.buttonData="RIGHT" />
+              <Button mnemonicParsing="false" onAction="#handleMoveDown" text="↓" ButtonBar.buttonData="RIGHT" />
+              <Button mnemonicParsing="false" onAction="#handleAdd" text="+" ButtonBar.buttonData="LEFT" />
+              <Button mnemonicParsing="false" onAction="#handleRemove" text="-" ButtonBar.buttonData="LEFT" />
+          </buttons>
+        </ButtonBar>
+        <ListView fx:id="dictionary_list" style=": ;" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" GridPane.vgrow="ALWAYS" />
+     </children>
+   <padding>
+      <Insets bottom="10.0" left="10.0" right="10.0" />
+   </padding>
+</GridPane>

--- a/src/main/resources/view/FilterPane.fxml
+++ b/src/main/resources/view/FilterPane.fxml
@@ -1,55 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<ScrollPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.FilterPaneController">
-   <content>
-      <AnchorPane prefHeight="263.0" prefWidth="175.0">
-         <children>
-            <GridPane layoutX="14.0" layoutY="14.0">
-               <columnConstraints>
-                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
-               </columnConstraints>
-               <rowConstraints>
-                  <RowConstraints />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
-               </rowConstraints>
-               <children>
-                  <Label text="Filter" GridPane.rowIndex="1">
-                     <font>
-                        <Font name="System Bold" size="14.0" />
-                     </font></Label>
-                  <Label text="Translation:" GridPane.rowIndex="2" />
-                  <TextField id="translation" fx:id="translation" onAction="#onTranslationTextChange" styleClass="emoji-field" GridPane.rowIndex="3" />
-                  <Label text="Stroke:" GridPane.rowIndex="4" />
-                  <TextField id="stroke" fx:id="stroke" onAction="#onTranslationTextChange" styleClass="mono-font" GridPane.rowIndex="5" />
-                  <Label text="Number of strokes:" GridPane.rowIndex="6" />
-                  <TextField id="chordCount" fx:id="chordCount" onAction="#onTranslationTextChange" GridPane.rowIndex="7" />
-                  <Label text="Number of words:" GridPane.rowIndex="8" />
-                  <TextField id="wordCount" fx:id="wordCount" onAction="#onTranslationTextChange" GridPane.rowIndex="9" />
-                  <Label text="Dictionary:" GridPane.rowIndex="10" />
-                  <ChoiceBox fx:id="dictionary_box" onAction="#onTranslationTextChange" prefWidth="150.0" value="Any" GridPane.rowIndex="11" />
-               </children>
-            </GridPane>
-         </children>
-      </AnchorPane>
-   </content>
-</ScrollPane>
+<GridPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.FilterPaneController">
+  <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" />
+  </columnConstraints>
+  <rowConstraints>
+      <RowConstraints />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+      <RowConstraints vgrow="NEVER" />
+   </rowConstraints>
+   <children>
+      <Label text="Filter" GridPane.rowIndex="1">
+         <font>
+            <Font name="System Bold" size="14.0" />
+         </font></Label>
+      <Label text="Translation:" GridPane.rowIndex="2">
+        <padding>
+           <Insets top="5.0" />
+        </padding></Label>
+      <TextField id="translation" fx:id="translation" onAction="#onTranslationTextChange" styleClass="emoji-field" GridPane.rowIndex="3" />
+      <Label text="Stroke:" GridPane.rowIndex="4">
+        <padding>
+           <Insets top="5.0" />
+        </padding></Label>
+      <TextField id="stroke" fx:id="stroke" onAction="#onTranslationTextChange" styleClass="mono-font" GridPane.rowIndex="5" />
+      <Label text="Number of strokes:" GridPane.rowIndex="6">
+        <padding>
+           <Insets top="5.0" />
+        </padding></Label>
+      <TextField id="chordCount" fx:id="chordCount" onAction="#onTranslationTextChange" GridPane.rowIndex="7" />
+      <Label text="Number of words:" GridPane.rowIndex="8">
+        <padding>
+           <Insets top="5.0" />
+        </padding></Label>
+      <TextField id="wordCount" fx:id="wordCount" onAction="#onTranslationTextChange" GridPane.rowIndex="9" />
+      <Label text="Dictionary:" GridPane.rowIndex="10">
+        <padding>
+           <Insets top="5.0" />
+        </padding></Label>
+      <ChoiceBox fx:id="dictionary_box" onAction="#onTranslationTextChange" value="Any" GridPane.rowIndex="11" />
+   </children>
+  <padding>
+     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+  </padding>
+</GridPane>

--- a/src/main/resources/view/Main.fxml
+++ b/src/main/resources/view/Main.fxml
@@ -4,12 +4,13 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="480.0" prefWidth="768.0" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.MainController">
-   <top>
-      <MenuBar prefHeight="26.0" prefWidth="814.0" BorderPane.alignment="CENTER">
+<GridPane xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="bozzy.controllers.MainController">
+   <children>
+      <MenuBar prefHeight="26.0" GridPane.rowIndex="1" GridPane.hgrow="ALWAYS">
         <menus>
           <Menu mnemonicParsing="false" text="File">
             <items>
@@ -34,22 +35,24 @@
             </Menu>
         </menus>
       </MenuBar>
-   </top>
-   <center>
-      <SplitPane dividerPositions="0.29" prefHeight="499.0" prefWidth="946.0" BorderPane.alignment="CENTER">
-        <items>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
-               <children>
-                  <SplitPane dividerPositions="0.5982905982905983" layoutX="32.0" layoutY="66.0" orientation="VERTICAL" prefHeight="373.0" prefWidth="175.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                     <items>
-                        <fx:include source="FilterPane.fxml" />
-                        <fx:include source="DictionaryList.fxml" />
-                     </items>
-                  </SplitPane>
-               </children>
-            </AnchorPane>
-            <fx:include prefHeight="Infinity" prefWidth="Infinity" source="DictionaryContentPane.fxml" />
-        </items>
-      </SplitPane>
-   </center>
-</BorderPane>
+       <SplitPane dividerPositions="0.270935960591133" prefHeight="559.0" prefWidth="800.0" GridPane.rowIndex="2" GridPane.vgrow="ALWAYS" GridPane.hgrow="ALWAYS">
+           <items>
+               <SplitPane dividerPositions="0.585278276481149" orientation="VERTICAL" SplitPane.resizableWithParent="false">
+                   <fx:include source="FilterPane.fxml" SplitPane.resizableWithParent="true" />
+                   <fx:include source="DictionaryList.fxml" SplitPane.resizableWithParent="true"/>
+               </SplitPane>
+               <fx:include source="DictionaryContentPane.fxml" SplitPane.resizableWithParent="true"/>
+           </items>
+       </SplitPane>
+    </children>
+   <columnConstraints>
+      <ColumnConstraints />
+      <ColumnConstraints />
+      <ColumnConstraints />
+   </columnConstraints>
+   <rowConstraints>
+      <RowConstraints />
+      <RowConstraints />
+      <RowConstraints />
+   </rowConstraints>
+</GridPane>

--- a/src/main/scala/bozzy/steno/StenoDictionary.scala
+++ b/src/main/scala/bozzy/steno/StenoDictionary.scala
@@ -1,5 +1,7 @@
 package bozzy.steno
 
+import java.io.File
+
 import scala.io.Source
 import scalafx.collections.ObservableBuffer
 
@@ -8,7 +10,7 @@ import scalafx.collections.ObservableBuffer
   */
 class StenoDictionary(val filename: String, val format: DictionaryFormat.Value) {
   val entries = ObservableBuffer[DictionaryEntry]()
-  val dictionaryName = filename.split('/').last
+  val dictionaryName = new File(filename) getName
 
   if (format == DictionaryFormat.RTF) {
 


### PR DESCRIPTION
A combination of splitpanes, gridpanes, and resizability constraints makes
the UI respond much better to resizing.
Here's what I found:

For a flexible automatically-resized layout, use GridPane and apply the
GridPane.hgrow + GridPane.vgrow attributes as needed to make sure they
fill the entire space.
For a user-resizable area, we can keep using SplitPanes.
It turns out AnchorPanes/BorderPanes aren't actually needed in our case,
we can mostly just stick to GridPanes and all will be well.

I also fixed the filename issue, this solution should work on all
Platforms since it's using the Java.io package.