### PR TITLE
Normalize steno strokes

### DIFF
--- a/src/main/scala/bozzy/steno/DictionaryEntry.scala
+++ b/src/main/scala/bozzy/steno/DictionaryEntry.scala
@@ -9,7 +9,10 @@ class DictionaryEntry(entryStroke: String,
                       entryTranslation: String,
                       val format: DictionaryFormat.Value,
                       val dictionary: StenoDictionary) {
-  val translation = new Translation(entryTranslation, format)
+  val translation = format match {
+    case DictionaryFormat.RTF => new RTFTranslation(entryTranslation)
+    case DictionaryFormat.JSON => new JSONTranslation(entryTranslation)
+  }
   val stroke = new Stroke(entryStroke, format)
 
   // Readable columns.
@@ -23,7 +26,7 @@ class DictionaryEntry(entryStroke: String,
 
   def matches(other: DictionaryEntry): Boolean =
     other.translation.raw == this.translation.raw &&
-      other.stroke.raw == this.stroke.raw
+      other.stroke.normal == this.stroke.normal
 }
 
 object DictionaryEntry {
@@ -37,12 +40,12 @@ object DictionaryEntry {
     val intWordCount = try {
       wordCount.toInt
     } catch {
-      case e: NumberFormatException => None
+      case _: NumberFormatException => None
     }
     val intChordCount = try {
       chordCount.toInt
     } catch {
-      case e: NumberFormatException => None
+      case _: NumberFormatException => None
     }
     val noChordCount = chordCount == null || chordCount.isEmpty || intChordCount == None
     val noWordCount = wordCount == null || wordCount.isEmpty || intWordCount == None

--- a/src/main/scala/bozzy/steno/StenoDictionary.scala
+++ b/src/main/scala/bozzy/steno/StenoDictionary.scala
@@ -1,6 +1,7 @@
 package bozzy.steno
 
 import java.io.File
+import java.nio.charset.MalformedInputException
 
 import scala.io.Source
 import scalafx.collections.ObservableBuffer
@@ -19,7 +20,7 @@ class StenoDictionary(val filename: String, val format: DictionaryFormat.Value) 
         .foreach((entry: (String, String)) =>
           entries add new DictionaryEntry(entry._1, entry._2, DictionaryFormat.RTF, this))
     } catch {
-      case _: Exception => {
+      case _: MalformedInputException => {
         // But most traditional steno dictionaries will be in ANSI
         entries removeAll entries
         DictionaryFormat.parseRtfDictionary(Source.fromFile(filename, "Cp1252").mkString)
@@ -28,7 +29,9 @@ class StenoDictionary(val filename: String, val format: DictionaryFormat.Value) 
       }
     }
   } else if (format == DictionaryFormat.JSON) {
-    val jsonDictionaryString = Source.fromFile(filename).mkString
+    val jsonDictionaryString = try Source.fromFile(filename).mkString catch {
+      case _: MalformedInputException => Source.fromFile(filename, "Cp1252").mkString
+    }
     DictionaryFormat.parseJsonDictionary(jsonDictionaryString).foreach((entry: (String, String)) =>
       entries add new DictionaryEntry(entry._1, entry._2, DictionaryFormat.JSON, this))
   }

--- a/src/main/scala/bozzy/steno/StenoLayout.scala
+++ b/src/main/scala/bozzy/steno/StenoLayout.scala
@@ -1,5 +1,7 @@
 package bozzy.steno
 
+import java.util.regex.Pattern
+
 /**
   * Created by ted on 2016-02-08.
   */
@@ -7,19 +9,143 @@ class StenoLayout( val name: String
                  , val beginningKeys: String
                  , val centerKeys: Tuple2[String, String]
                  , val endingKeys: String
-                 )
+                 , val flag: String = ""
+                 ) {
+  val groupPattern = {
+    val builder = new StringBuilder((beginningKeys.length +
+      centerKeys._1.length + endingKeys.length) * 2 + 16)
+    builder ++= "^("
+    beginningKeys foreach(character => {
+      builder ++= StenoLayout.characterToEscapedString(character)
+      builder += '?'
+    })
+    builder ++= ")?("
+    centerKeys._1 foreach(character => {
+      builder ++= StenoLayout.characterToEscapedString(character)
+      builder += '?'
+    })
+    builder ++= ")?("
+    endingKeys foreach(character => {
+      builder ++= StenoLayout.characterToEscapedString(character)
+      builder += '?'
+    })
+    builder ++= ")?$"
+    builder.toString.r
+  }
+}
 
 object StenoLayout {
   val STANDARD_STENO_LAYOUT =
     new StenoLayout( "English Stenography"
                    , "STKPWHR"
-                   , ("AO*EU", "-")
-                   , "FRPBLGTSZD"
+                   , ("AO-*EU", "-")
+                   , "FRPBLGTSDZ"
                    )
   val STANDARD_NUMBER_LAYOUT =
     new StenoLayout( "English Stenography Number Bar"
                    , "12K3W4R"
-                   , ("50*EU", "-")
+                   , ("50-*EU", "-")
                    , "6R7B8G9SDZ"
+                   , "#"
                    )
+  val numeric = """\d""".r
+
+  /** Normalize a set of chords, separated by the '/' character.
+    *
+    * Parses a stroke; a set of chords; into a consistent format
+    * and returns whether or not the stroke is valid syntax according
+    * to the steno layout.
+    */
+  def normalizeStroke(stroke: String) = {
+    val chords = (stroke split '/')
+    if (stroke.charAt(0) == '/' || stroke.last == '/') {
+      (stroke, false)
+    } else {
+      def assembleChords(remaining: Array[String], result: StringBuilder): (String, Boolean) = {
+        val (chord, valid) = normalizeChord(remaining.head)
+        if (!valid) {
+          (stroke, valid)
+        } else if (remaining.tail.size == 0) {
+          result ++= chord
+          (result.toString, valid)
+        } else {
+          result ++= s"$chord/"
+          assembleChords(remaining.tail, result)
+        }
+      }
+      assembleChords(chords, new StringBuilder(stroke.length))
+    }
+  }
+
+  /** Normalize a single chord to a unified format, and validate it.
+    *
+    * Parses a single chord, then spits out an equivalent chord in a
+    * consistent style, meaning that we can use it to compare
+    * identical chords that are formatted differently. We also validate
+    * the chord according to steno order and keys, and if the parsing
+    * fails, we return the given chord and valid false.
+    */
+  def normalizeChord(chord: String) = {
+    val result = new StringBuilder(chord.length * 2)
+    var valid = true // Will only return "normalized steno" if valid.
+
+    // Get right pattern if numeric or not.
+    val (pattern, cleaned) =
+      if (chord.contains(STANDARD_NUMBER_LAYOUT.flag) || // Contains #.
+        numeric.findFirstIn(chord).isDefined) { // Contains number.
+      val noHash = chord.replaceAllLiterally("#", "") // Get rid of #.
+      result += '#' // Result will start with #.
+      // Return pattern, cleaned up chord.
+      (STANDARD_NUMBER_LAYOUT.groupPattern, noHash.trim)
+    } else {
+      // Not as much to do for a regular chord.
+      (STANDARD_STENO_LAYOUT.groupPattern, chord.trim)
+    }
+    try {
+      // Split into the three sections. Will be empty string if not present.
+      val pattern(left, center, right) = cleaned
+      result ++= left
+      if (center.isEmpty && left.isEmpty) {
+        valid = false // Can only have left-hand or center without hyphen.
+      } else if (center == "-") {
+        // Ensure it's not just a hyphen...
+        if (left.isEmpty && right.isEmpty) {
+          valid = false
+        } else if (!right.isEmpty) {
+          // Leave necessary hyphen. Left doesn't need it.
+          result += '-'
+        }
+        // Leading left-hand stroke doesn't need hyphen.
+      } else if (center contains "-") {
+        // Drop if explicit hyphen if implicit hyphen is available.
+        val hyphenIndex = center indexOf '-'
+        result ++= center.substring(0, hyphenIndex)
+        if (center.size > hyphenIndex + 1) {
+          result ++= center.substring(hyphenIndex + 1)
+        }
+      } else {
+        // Result was previously implicit, keep it that way.
+        result ++= center
+      }
+      // Add right hand.
+      result ++= right
+    } catch {
+      // Occurs when characters aren't in steno order or don't match key set.
+      case _: MatchError => valid = false
+    }
+    (if (valid) result.toString else chord, valid)
+  }
+
+  def characterToEscapedString(character: Char): String =
+    character match { // Full list: \.[{(*+?^$|
+      case '\\' => "\\\\"
+      case '*' => "\\*"
+      case '+' => "\\+"
+      case '?' => "\\?"
+      case '^' => "\\^"
+      case '$' => "\\$"
+      case '.' => "\\."
+      case '|' => "\\|"
+      case _ => character.toString
+    }
 }

--- a/src/main/scala/bozzy/steno/Stroke.scala
+++ b/src/main/scala/bozzy/steno/Stroke.scala
@@ -4,5 +4,6 @@ package bozzy.steno
   * Created by ted on 2016-02-08.
   */
 class Stroke(val raw: String, format: DictionaryFormat.Value)  {
-  val chord_count: Int = (raw split '/').length
+  val (normal, valid) = StenoLayout.normalizeStroke(raw)
+  val chord_count = (raw split '/') length
 }

--- a/src/main/scala/bozzy/steno/Translation.scala
+++ b/src/main/scala/bozzy/steno/Translation.scala
@@ -3,6 +3,18 @@ package bozzy.steno
 /**
   * Created by ted on 2016-02-08.
   */
-class Translation(val raw: String, val format: DictionaryFormat.Value) {
+abstract class Translation(val raw: String, val format: DictionaryFormat.Value) {
   val word_count: Int = (raw split ' ').length
+  def toJSON: String
+  def toRTF: String
+}
+
+class RTFTranslation(override val raw: String) extends Translation(raw, DictionaryFormat.RTF) {
+  def toRTF = raw
+  def toJSON = raw // TODO: Implement conversion.
+}
+
+class JSONTranslation(override val raw: String) extends Translation(raw, DictionaryFormat.RTF) {
+  def toRTF = raw // TODO: Implement conversion.
+  def toJSON = raw
 }

--- a/src/test/scala/StenoInstantiationTest.scala
+++ b/src/test/scala/StenoInstantiationTest.scala
@@ -37,4 +37,14 @@ class StenoInstantiationTest extends FlatSpec with Matchers {
     dictionary.entries.size should equal (24)
   }
 
+  "Entry matching" should "use normalized strokes" in {
+    val absolutePath = getClass.getResource("/sampleJSONDictionary.json").getPath()
+    val dictionary = new StenoDictionary(absolutePath, DictionaryFormat.JSON)
+    // A- is equivalent to A.
+    val entry = new DictionaryEntry("A-", "{a^}", DictionaryFormat.JSON, dictionary)
+    val secondEntry = new DictionaryEntry("A", "{a^}", DictionaryFormat.JSON, dictionary)
+    entry.matches(secondEntry) should be (true)
+    // TODO: Test against matching across format translations, e.g.:
+    // "{a^}" == "a\cxds "
+  }
 }

--- a/src/test/scala/StrokeNormalizationTest.scala
+++ b/src/test/scala/StrokeNormalizationTest.scala
@@ -1,0 +1,78 @@
+import bozzy.steno.StenoLayout
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Created by ted on 2016-04-15.
+  */
+class StrokeNormalizationTest extends FlatSpec with Matchers {
+  "normalizeChord" should "parse numberic chords" in {
+    val tests = Map(
+      "#1234-6789" -> "#1234-6789",
+      "1234-6789" -> "#1234-6789",
+      "1234#-6789" -> "#1234-6789",
+      "#K-" -> "#K",
+      "-6R7B" -> "#-6R7B",
+      "50-R" -> "#50R",
+      "12K3W4R" -> "#12K3W4R",
+      "K5#" -> "#K5",
+      "12K3W4R50*EU6R7B8G9SDZ" -> "#12K3W4R50*EU6R7B8G9SDZ",
+      "#" -> "#"
+    )
+    tests foreach((chordPair: (String, String)) => {
+      val (before, after) = chordPair
+      StenoLayout.normalizeChord(before)._1 should equal (after)
+    })
+  }
+
+  "normalizeChord" should "detect invalid strokes" in {
+    val tests = List("1A", "#-", "-")
+    tests foreach(stroke =>
+      StenoLayout.normalizeChord(stroke)._2 should be (false)
+    )
+  }
+
+  "normalizeChord" should "parse regular chords" in {
+    val tests = Map(
+      "STKP-" -> "STKP",
+      "-FRPB" -> "-FRPB",
+      "STKPWHRAO*EUFRPBLGTSDZ" -> "STKPWHRAO*EUFRPBLGTSDZ",
+      "*D" -> "*D",
+      "WR" -> "WR",
+      "WR-" -> "WR",
+      "*" -> "*",
+      "R-EU" -> "REU",
+      "S-S" -> "S-S",
+      "AOEU" -> "AOEU"
+    )
+    tests foreach((chordPair: (String, String)) => {
+      val (before, after) = chordPair
+      StenoLayout.normalizeChord(before)._1 should equal (after)
+    })
+  }
+
+  "normalizeStroke" should "parse a multi-stroke entry" in {
+    val tests = Map(
+      "STK-/TPHO-T" -> "STK/TPHOT",
+      "RAO-EUR/RAOEUR/R-R/AOEU/AO-EU" -> "RAOEUR/RAOEUR/R-R/AOEU/AOEU"
+    )
+    tests foreach ((strokePair: (String, String)) => {
+      val (before, after) = strokePair
+      StenoLayout.normalizeStroke(before)._1 should equal (after)
+    })
+  }
+
+  "normalizeStroke" should "correctly report invalid strokes" in {
+    val tests = List(
+      "STK-/TPHO--T",
+      "STK-//STK",
+      "STK-/"
+    )
+    tests foreach (stroke => {
+      val result = StenoLayout.normalizeStroke(stroke)
+      result._1 should equal (stroke)
+      result._2 should be (false)
+    })
+  }
+
+}
+


### PR DESCRIPTION
Normalize the steno strokes into one format, in order to account for discrepancies among dictionaries.

I tend to err on the side of shortest syntax, except for numbers where I always explicitly leave the "#" symbol at the very beginning.

I tried loading 1.5 million entries across 9 dictionaries and it was no slower than one would expect from that count (15-20 seconds, about the same as without this new code.)

I think this implementation merits examination, @sofa13 @Germanika @edalp008 