### PR TITLE
Normalize numbers to letter keys instead of storing numbers

### DIFF
--- a/src/main/scala/bozzy/steno/StenoLayout.scala
+++ b/src/main/scala/bozzy/steno/StenoLayout.scala
@@ -9,7 +9,8 @@ class StenoLayout( val name: String
                  , val beginningKeys: String
                  , val centerKeys: Tuple2[String, String]
                  , val endingKeys: String
-                 , val flag: String = ""
+                 , val numberKey: String = ""
+                 , val numberMapping: Map[String, String] = Map()
                  ) {
   val groupPattern = {
     val builder = new StringBuilder((beginningKeys.length +
@@ -37,16 +38,22 @@ class StenoLayout( val name: String
 object StenoLayout {
   val STANDARD_STENO_LAYOUT =
     new StenoLayout( "English Stenography"
-                   , "STKPWHR"
+                   , "#STKPWHR"
                    , ("AO-*EU", "-")
                    , "FRPBLGTSDZ"
-                   )
-  val STANDARD_NUMBER_LAYOUT =
-    new StenoLayout( "English Stenography Number Bar"
-                   , "12K3W4R"
-                   , ("50-*EU", "-")
-                   , "6R7B8G9SDZ"
                    , "#"
+                   , Map(
+                      "1" -> "S",
+                      "2" -> "T",
+                      "3" -> "P",
+                      "4" -> "H",
+                      "5" -> "A",
+                      "0" -> "O",
+                      "6" -> "F",
+                      "7" -> "P",
+                      "8" -> "L",
+                      "9" -> "T"
+                     )
                    )
   val numeric = """\d""".r
 
@@ -91,12 +98,15 @@ object StenoLayout {
 
     // Get right pattern if numeric or not.
     val (pattern, cleaned) =
-      if (chord.contains(STANDARD_NUMBER_LAYOUT.flag) || // Contains #.
+      if (chord.contains(STANDARD_STENO_LAYOUT.numberKey) || // Contains #.
         numeric.findFirstIn(chord).isDefined) { // Contains number.
       val noHash = chord.replaceAllLiterally("#", "") // Get rid of #.
       result += '#' // Result will start with #.
+      val withoutNumbers = noHash.map(key =>
+            STANDARD_STENO_LAYOUT.numberMapping.getOrElse(key.toString, key)
+          ).mkString
       // Return pattern, cleaned up chord.
-      (STANDARD_NUMBER_LAYOUT.groupPattern, noHash.trim)
+      (STANDARD_STENO_LAYOUT.groupPattern, withoutNumbers.trim)
     } else {
       // Not as much to do for a regular chord.
       (STANDARD_STENO_LAYOUT.groupPattern, chord.trim)

--- a/src/test/scala/StrokeNormalizationTest.scala
+++ b/src/test/scala/StrokeNormalizationTest.scala
@@ -7,15 +7,15 @@ import org.scalatest.{FlatSpec, Matchers}
 class StrokeNormalizationTest extends FlatSpec with Matchers {
   "normalizeChord" should "parse numberic chords" in {
     val tests = Map(
-      "#1234-6789" -> "#1234-6789",
-      "1234-6789" -> "#1234-6789",
-      "1234#-6789" -> "#1234-6789",
+      "#1234-6789" -> "#STPH-FPLT",
+      "1234-6789" -> "#STPH-FPLT",
+      "1234#-6789" -> "#STPH-FPLT",
       "#K-" -> "#K",
-      "-6R7B" -> "#-6R7B",
-      "50-R" -> "#50R",
-      "12K3W4R" -> "#12K3W4R",
-      "K5#" -> "#K5",
-      "12K3W4R50*EU6R7B8G9SDZ" -> "#12K3W4R50*EU6R7B8G9SDZ",
+      "-6R7B" -> "#-FRPB",
+      "50-R" -> "#AOR",
+      "12K3W4R" -> "#STKPWHR",
+      "K5#" -> "#KA",
+      "12K3W4R50*EU6R7B8G9SDZ" -> "#STKPWHRAO*EUFRPBLGTSDZ",
       "#" -> "#"
     )
     tests foreach((chordPair: (String, String)) => {
@@ -25,7 +25,7 @@ class StrokeNormalizationTest extends FlatSpec with Matchers {
   }
 
   "normalizeChord" should "detect invalid strokes" in {
-    val tests = List("1A", "#-", "-")
+    val tests = List("TSKJ", "-", "321-")
     tests foreach(stroke =>
       StenoLayout.normalizeChord(stroke)._2 should be (false)
     )


### PR DESCRIPTION
This change simplifies how we store the normalized strokes -- plain key representations instead of a different "layout" for the numbers. From a data storage point of view, this makes more sense than actually storing numbers. It's a little crazy that old steno machines actually output numbers manually with a switch.